### PR TITLE
Don't error if MCFX is blocked on the page

### DIFF
--- a/mcfx-select.js
+++ b/mcfx-select.js
@@ -2,7 +2,7 @@
 
     $('.webform-submission-swim-lesson-selector-form').on( 'input', e => {
         const form = e.currentTarget
-        if( 'undefined' !== MCFX ) {
+        if( "MCFX" in window ) {
             MCFX.Form.submit( form )
             console.log('form-submmited')
         }


### PR DESCRIPTION
If the MCFX script (`https://cdn.leadmanagerfx.com/js/mcfx/1085`) is blocked, for instance by an adblocker, `mcfx-select.js` will error with `mcfx-select.js:5 Uncaught ReferenceError: MCFX is not defined` and block further interaction. Changing the check here should rectify the error.